### PR TITLE
Adding optional interfaceAssociatedAddress to UDPReceiver c'tor

### DIFF
--- a/libcluon/include/cluon/UDPReceiver.hpp
+++ b/libcluon/include/cluon/UDPReceiver.hpp
@@ -86,11 +86,14 @@ class LIBCLUON_API UDPReceiver {
      * @param receiveFromPort Port to receive UDP packets from.
      * @param delegate Functional (noexcept) to handle received bytes; parameters are received data, sender, timestamp.
      * @param localSendFromPort Port that an application is using to send data. This port (> 0) is ignored when data is received.
+     * @param interfaceAssociatedAddress Optional numerical IPv4 address associated with a interface. If given, will be used to
+     * specify which interface to use when joining a multicast group.
      */
     UDPReceiver(const std::string &receiveFromAddress,
                 uint16_t receiveFromPort,
                 std::function<void(std::string &&, std::string &&, std::chrono::system_clock::time_point &&)> delegate,
-                uint16_t localSendFromPort = 0) noexcept;
+                uint16_t localSendFromPort                    = 0,
+                const std::string &interfaceAssociatedAddress = "") noexcept;
     ~UDPReceiver() noexcept;
 
     /**

--- a/libcluon/src/UDPReceiver.cpp
+++ b/libcluon/src/UDPReceiver.cpp
@@ -54,7 +54,8 @@ namespace cluon {
 UDPReceiver::UDPReceiver(const std::string &receiveFromAddress,
                          uint16_t receiveFromPort,
                          std::function<void(std::string &&, std::string &&, std::chrono::system_clock::time_point &&)> delegate,
-                         uint16_t localSendFromPort) noexcept
+                         uint16_t localSendFromPort,
+                         const std::string &interfaceAssociatedAddress) noexcept
     : m_localSendFromPort(localSendFromPort)
     , m_receiveFromAddress()
     , m_mreq()
@@ -236,8 +237,8 @@ UDPReceiver::UDPReceiver(const std::string &receiveFromAddress,
             if (m_isMulticast) {
                 // Join the multicast group.
                 m_mreq.imr_multiaddr.s_addr = ::inet_addr(receiveFromAddress.c_str());
-                m_mreq.imr_interface.s_addr = htonl(INADDR_ANY);
                 // clang-format off
+                m_mreq.imr_interface.s_addr = interfaceAssociatedAddress.empty() ? htonl(INADDR_ANY) : ::inet_addr(interfaceAssociatedAddress.c_str());
                 auto retval                 = ::setsockopt(m_socket, IPPROTO_IP, IP_ADD_MEMBERSHIP, reinterpret_cast<char *>(&m_mreq), sizeof(m_mreq)); // NOLINT
                 // clang-format on
                 if (0 > retval) { // LCOV_EXCL_LINE


### PR DESCRIPTION
Adding optional constructor argument for allowing explicit interface address to be used when joining a multicast group. This makes it possible to explicitly set which interface that should be used when joining a multicast group on a computer with multiple NICs.