### PR TITLE
fix bug

### DIFF
--- a/libcluon/include/cluon/TCPConnection.hpp
+++ b/libcluon/include/cluon/TCPConnection.hpp
@@ -145,6 +145,7 @@ class LIBCLUON_API TCPConnection {
    private:
     mutable std::mutex m_socketMutex{};
     int32_t m_socket{-1};
+    bool m_cleanup{true};//if not created from TCPServer,call WSACleanup
     struct sockaddr_in m_address {};
 
     std::atomic<bool> m_readFromSocketThreadRunning{false};

--- a/libcluon/src/TCPConnection.cpp
+++ b/libcluon/src/TCPConnection.cpp
@@ -40,6 +40,7 @@ namespace cluon {
 
 TCPConnection::TCPConnection(const int32_t &socket) noexcept
     : m_socket(socket)
+    , m_cleanup(false)
     , m_newDataDelegate(nullptr)
     , m_connectionLostDelegate(nullptr) {
     if (!(m_socket < 0)) {
@@ -135,7 +136,9 @@ void TCPConnection::closeSocket(int errorCode) noexcept {
 #ifdef WIN32
         ::shutdown(m_socket, SD_BOTH);
         ::closesocket(m_socket);
-        WSACleanup();
+        if(m_cleanup){
+            WSACleanup();
+        }
 #else
         ::shutdown(m_socket, SHUT_RDWR);                                             // Disallow further read/write operations.
         ::close(m_socket);


### PR DESCRIPTION
When TCPConnection is created from TCPServer, should not call WSACleanup in closeSocket() on windows