### PR TITLE
Update cluon-msc.hpp

### DIFF
--- a/libcluon/tools/cluon-msc.hpp
+++ b/libcluon/tools/cluon-msc.hpp
@@ -37,8 +37,7 @@ inline int32_t cluon_msc(int32_t argc, char **argv) {
         return 1;
     }
 
-    std::string outputFilename;
-    commandline({"--out"}) >> outputFilename;
+    std::string outputFilename = commandline("--out").str();
 
     const bool generateCPP = commandline[{"--cpp"}];
     const bool generateProto = commandline[{"--proto"}];


### PR DESCRIPTION
The current version of cluon-msc cannot handle spaces in the output path (even when escaped). The commit should fix the problem.

Below is the output from the current version:

```
[ola@shew cluon-test]$ ls
cluon-msc  in.odvd
[ola@shew cluon-test]$ ./cluon-msc --cpp --out="${PWD}/out.hpp" "${PWD}/in.odvd"
[ola@shew cluon-test]$ ls
cluon-msc  in.odvd  out.hpp
```

```
[ola@shew cluon test]$ ls
cluon-msc  in.odvd
[ola@shew cluon test]$ ./cluon-msc --cpp --out="${PWD}/out.hpp" "${PWD}/in.odvd"
[ola@shew cluon test]$ ls
cluon-msc  in.odvd
```